### PR TITLE
add LoongArch64 support.

### DIFF
--- a/fitsio2.h
+++ b/fitsio2.h
@@ -103,6 +103,10 @@ extern int Fitsio_Pthread_Status;
 #define BYTESWAPPED TRUE
 #define LONGSIZE 64   
 
+#elif defined(__loongarch64)   /* LoongArch 64-bit */
+#define BYTESWAPPED TRUE
+#define LONGSIZE 64   
+
 #elif defined(_SX)             /* Nec SuperUx */
 
 #define BYTESWAPPED FALSE


### PR DESCRIPTION
This patch is to solve the failure of  'testprog CFITSIO TESTP ROG' on LoongArch64.